### PR TITLE
Make remote name configuable with `github-actions.remoteName`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
           "description": "Whether org features should be enabled. Requires the `admin:org` scope",
           "default": false,
           "scope": "window"
+        },
+        "github-actions.remoteName": {
+          "type": "string",
+          "description": "The remote name to explorer workflows",
+          "default": "origin",
+          "scope": "window"
         }
       }
     },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -7,6 +7,8 @@ export function initConfiguration(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration(getSettingsKey("workflows.pinned"))) {
         pinnedWorkflowsChangeHandlers.forEach((h) => h());
+      } else if (e.affectsConfiguration(getSettingsKey("remoteName"))) {
+        remoteNameChangedHandlers.forEach((h) => h());
       }
     })
   );
@@ -23,6 +25,11 @@ function getSettingsKey(settingsPath: string): string {
 const pinnedWorkflowsChangeHandlers: (() => void)[] = [];
 export function onPinnedWorkflowsChange(handler: () => void) {
   pinnedWorkflowsChangeHandlers.push(handler);
+}
+
+const remoteNameChangedHandlers: (() => void)[] = [];
+export function onRemoteNameChanged(handler: () => void) {
+  remoteNameChangedHandlers.push(handler);
 }
 
 export function getPinnedWorkflows(): string[] {
@@ -56,4 +63,8 @@ export async function updateOrgFeaturesEnabled(enabled: boolean) {
     enabled,
     true
   );
+}
+
+export function remoteName(): string {
+  return getConfiguration().get<string>(getSettingsKey("remoteName"), "origin");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { enableOrgFeatures } from "./auth/auth";
-import { initConfiguration } from "./configuration/configuration";
-import { getGitHubContext, GitHubContext } from "./git/repository";
+import { initConfiguration, onRemoteNameChanged } from "./configuration/configuration";
+import { getGitHubContext, GitHubContext, resetGitHubContext } from "./git/repository";
 import { LogScheme } from "./logs/constants";
 import { WorkflowStepLogProvider } from "./logs/fileProvider";
 import { WorkflowStepLogFoldingProvider } from "./logs/foldingProvider";
@@ -57,6 +57,12 @@ export function activate(context: vscode.ExtensionContext) {
       settingsTreeProvider
     )
   );
+
+  onRemoteNameChanged(() => {
+    resetGitHubContext();
+    workflowTreeProvider.refresh();
+    settingsTreeProvider.refresh();
+  });
 
   context.subscriptions.push(
     vscode.commands.registerCommand("github-actions.explorer.refresh", () => {

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -2,6 +2,7 @@ import { Octokit } from "@octokit/rest";
 import * as vscode from "vscode";
 import { getClient } from "../api/api";
 import { getSession } from "../auth/auth";
+import { remoteName } from "../configuration/configuration";
 import { Protocol } from "../external/protocol";
 import { GitExtension } from "../typings/git";
 import { flatten } from "../utils/array";
@@ -35,9 +36,10 @@ export async function getGitHubUrl(): Promise<string | null> {
     if (git.repositories.length > 0) {
       // To keep it very simple for now, look for the first remote in the current workspace that is a
       // github.com remote. This will be the repository for the workflow explorer.
+      const targetRemoteName = remoteName();
       const originRemotes = flatten(
         git.repositories.map((r) =>
-          r.state.remotes.filter((remote) => remote.name === "origin")
+          r.state.remotes.filter((remote) => remote.name === targetRemoteName)
         )
       );
 


### PR DESCRIPTION
As I issued https://github.com/cschleiden/vscode-github-actions/issues/56, multi-remote is ideal, but its changes might be too large.

So I'd like to support a custom remote other than `origin` so far. At least it works for me. What do you think of it?