### PR TITLE
Expand workflow run tree instead of opening in the browser on click

### DIFF
--- a/src/treeViews/workflows/workflowRunNode.ts
+++ b/src/treeViews/workflows/workflowRunNode.ts
@@ -32,12 +32,6 @@ export class WorkflowRunNode extends vscode.TreeItem {
       this.contextValue += "completed";
     }
 
-    this.command = {
-      title: "Open run",
-      command: "github-actions.workflow.run.open",
-      arguments: [this],
-    };
-
     this.iconPath = getIconForWorkflowRun(this.run);
     this.tooltip = `${this.run.status} ${this.run.conclusion || ""}`;
   }


### PR DESCRIPTION
When I click on the `workflow run` item it opens directly in the browser instead of expanding to show the jobs list.

I think it is better to expand the tree by default and if someone wants to open it in the browser they can just right click it -> `Open workflow run`

To show the jobs list I have to click the small arrow button and if I miss it, it opens in the browser.
![Capture](https://user-images.githubusercontent.com/90207354/132505643-e3564091-e97c-4e89-8ecd-c1ed45e16516.PNG)
