### PR TITLE
Exclude media and source map from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,3 +6,5 @@ tsconfig.json
 webpack.config.js
 !node_modules/keytar
 runners
+media
+dist/*.map


### PR DESCRIPTION
Resolve #176

Package size down from 23M to 428K.