### PR TITLE
chore: Add Dependabot for NPM and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99


### PR DESCRIPTION
Noticed that the Actions were behind, so copied over a boilerplate config. NPM kept to monthly to reduce noise