### PR TITLE
Fetch correct repository name

### DIFF
--- a/src/logs/scheme.ts
+++ b/src/logs/scheme.ts
@@ -27,7 +27,7 @@ export function parseUri(uri: vscode.Uri): {
 
   return {
     owner: uri.authority,
-    repo: uri.path.split("/").slice(0, -1).join(""),
+    repo: uri.path.split("/").slice(0, 2).join(""),
     jobId: parseInt(uri.query, 10),
     stepName: uri.fragment,
   };


### PR DESCRIPTION
Fixes https://github.com/cschleiden/vscode-github-actions/issues/111. 
Uris with multiple slashes was causing issues parsing the repository name. This change makes the parsing stricter to fetch the correct repository name.